### PR TITLE
Parallelize tests and cleanup some cruft

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ pylint = "*"
 
 [packages]
 "e1839a8" = {path = ".", editable = true}
+pytest-xdist = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7fb4f6e21fa540901a763f26eff65153fa93673b9faada7af475ba0a5583cbc8"
+            "sha256": "3c85210fb84096954e93bddd532e7d801fd41af97dc44bebce2f5478d6896a46"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,8 +21,15 @@
                 "sha256:0e2eee3802163bd0605975ed1e284cafc23203919bfa80c0cc5d3cd2543aaf97",
                 "sha256:48d5d64790a5112cace1a8e28d228c3f1c5bd3ddbd986a5453172d2da19f47d5"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
             "version": "==2.3.0"
+        },
+        "apipkg": {
+            "hashes": [
+                "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
+                "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.3.*'",
+            "version": "==1.5"
         },
         "atomicwrites": {
             "hashes": [
@@ -47,24 +54,24 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c848ae99e09f2899c5f81b8fdad90b2ef1fb7a760b13f2b1e51a345f4fd11d2b",
-                "sha256:e225d9fa3f313049547bf510a54d5f0af82f70d53fe0c0f891a0a9f8d4474681"
+                "sha256:7fdc2f6f21372572fec9df52e70b5ae11c263fe5905fc61dbd7ac3b01350cb4a",
+                "sha256:e3ac48844b5ee6adafd27f6682efdd009a9c5f70abef0b72092d039ae3050279"
             ],
-            "version": "==1.7.67"
+            "version": "==1.7.77"
         },
         "botocore": {
             "hashes": [
-                "sha256:e578f2618d0076950bcbd6ac938471310b08c292277b49092b938c59788012a6",
-                "sha256:e9eea23c566c30c69879941c4183294b7d45d8d8ff7946669364d8bb48ed0c90"
+                "sha256:bcd30fdd029f4d402b39fd52d89e90cdc26b7fb1a56e4b5778e6eff00608fd11",
+                "sha256:d9a0d504034f75341dde22a8917531071205dff92cc3f5f0962a3605951792b0"
             ],
-            "version": "==1.10.67"
+            "version": "==1.10.77"
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
+                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.8.13"
         },
         "chardet": {
             "hashes": [
@@ -91,6 +98,14 @@
         "e1839a8": {
             "editable": true,
             "path": "."
+        },
+        "execnet": {
+            "hashes": [
+                "sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a",
+                "sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.3.*'",
+            "version": "==1.5.0"
         },
         "idna": {
             "hashes": [
@@ -132,7 +147,7 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==0.7.1"
         },
         "py": {
@@ -140,50 +155,65 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
             "version": "==1.5.4"
         },
         "pycryptodome": {
             "hashes": [
-                "sha256:010d6ec31de6416db7136f1b56ca85363e2980986a5d7dd0c18797e4a3a54184",
-                "sha256:264b3754f61f338cc4cfd6c9e00f5f8778fce73e20a37f4551ed0fa7fa1a5f25",
-                "sha256:2ed336bdd7bc1f227eb06964531933bfed6470012608bfc5eb6aaf6ddffe6137",
-                "sha256:3c3ddad19994247a1c00e8e30c3da00820627ecedc4aee5865967f84bad6f958",
-                "sha256:3f9caa51b039cd010eff75bf5dbc8dd995c8b45b6e4e8e54f5161960dbd8e9e3",
-                "sha256:416ea498d5fea189ceaef3cf9526939b5fdc7d06c8a42f47d5bb7938b74bdb07",
-                "sha256:53ffdd13fce5155bbd52f82738794ed8ae2ea9619c31931ed6061618e218c738",
-                "sha256:6211dd4025496441d5b61cdf4d3aa70b7db0413c87ffd79d9ad1e0ddf0634bba",
-                "sha256:6245567a6ff07eb518d3ec7bbe4a33cf2b4de9a50083a906b199488359d754c4",
-                "sha256:62af7c01cbf67de60937c98073767cea65c470103a4775b46d5ab09924d49bab",
-                "sha256:659432b58f5eaba280ecd139fe8394d369585224a1edfa7920a0f7c77bf9f8dc",
-                "sha256:6feea8a031701919983929e4a9c2ee36469d050cc7fd77bf86f364b0f9a961e7",
-                "sha256:7180dc3c3e002af1fb44bc7265a2aba4a318b0b00850d66cb935f90032529753",
-                "sha256:743c38d6331dfb9e672397306dfaad4b0524afa8ff1d07271ff50d6da70566e0",
-                "sha256:81a98457740c7eb6c9d90d1f8e84264b3446bbda9019f561e86f0972be30feb8",
-                "sha256:87f990b915e794e4a7526703696f03adfe99cbf72523c0eb40a06453e6f21ddb",
-                "sha256:98972d57dd9e7582ae608fedbd1d5ea0a60e58d586ad3a257bd091941498af6c",
-                "sha256:9906d10968e96bc98dd043380b982373baa6d1233f901d6b83fe604a1314c61c",
-                "sha256:9c7790ffd291c81b934fe0ca8155a67235d33f70d4914bbf7467a447d9dbcb09",
-                "sha256:a8acea6e8301176c5f58aee3c915958ea15523b67e3a9159929e3699608ec11a",
-                "sha256:aabdcc2a42c05614bd9b46d475237226e5127e352cae41a339f864cc8ec6f8c9",
-                "sha256:b064cc2bd8058b810b6bae240eaa6334af45094a46a6443e956e6a59097f5703",
-                "sha256:b3ee89825098c6f36bac7d4a41fb8a699a3922ac8c309b94cf433f77b6bc19fa",
-                "sha256:b64da7a09ee9edb912b61e88282dbe2a8f10bbc2a58f33eef755b4b3274521b0",
-                "sha256:b69303ad2c3beca33d872dc8c1a73e83cc8733233d3454a1266f09d6e0cea9ff",
-                "sha256:c41c2167292f4bea115c9a566728ecdc05b8a6b0788c734a32c1fc9425b2bc69",
-                "sha256:d1569e5e0d79730b60a0c08120b3a84ce5ecd8461c1c8b76ebde49b423296066",
-                "sha256:ea2b9f7edd1ac89d8445a1800f52b2e506e3b9d643b95a44f53fb8f59cf167fd",
-                "sha256:eda82b564990e1d58e6c0d6646581aaf5b50567b05130efe71f3c6be0e11bf38",
-                "sha256:edfee1d19a7865add83463e92c6a7810e824ae9a10c9abb95b1763263f7e247c"
+                "sha256:02efa83b54371c468710ab2046ce2e254b512ebc2b1ce0d0d39a27b99c3b4b5d",
+                "sha256:08b5fe4679f0abf933cb51601c0fd1eaa0162218e5376216b52d67ec9e15fa87",
+                "sha256:08bce87c4631259ccf539b79dfa159022b5f5509068cfdc98094b6f7aed59942",
+                "sha256:0c98aa60c77418e5630c68e53ff18082e1c61f02136f3c6c06a9a456274db2cf",
+                "sha256:108652deb58d5daabf8cc1f31b821b9c9ee25101249ea6d88d09bb9de6cbeb07",
+                "sha256:111e05763f5834e4a05845ba6eff51db40d767314c9488dcc1ae7ac244b36001",
+                "sha256:14c4dab655b566b7b692bcfb9e9a48fd4a8bae18387e554f141203ae4737d263",
+                "sha256:242bc6384fc7acdcfad657921dca0d85d8a7de524463faa3b3a8d43c4285c689",
+                "sha256:248260a614fd8a3b28e26bb76064cf4d590098c9d37cd53736d8e5f5551e8260",
+                "sha256:2bc42b15c3e5dded13140a668d91cdfbec401d5e8e33bdc04eccfaddc6572d9d",
+                "sha256:2c0b45de63a904b0d995e9a82e5440f45cdd24d99566c2dd014c701d53813603",
+                "sha256:3e14dd6090dd88d4155451ced752d900a0d646c6fb74a772a5b68ab24fcb1c38",
+                "sha256:3fa6a292aa91f2be89f36844bb442a6e922a7facd82ce6a473949a08d7acb371",
+                "sha256:63de75b4639d3f916e13bfce77ea29bcc7c946a43a3ddb53131d0bda1612a704",
+                "sha256:666ef7aa4bbd3fe450aeddcb693113bd5d702938b803ae6591873b52217f36c6",
+                "sha256:69db6c222b689f746e092894c8f7b2b4e62e70bf8caf728baa93b3a40a2ecc08",
+                "sha256:76fc24aa3f2661680c590e90d716e66f5798e0c789554069483ce8644359be92",
+                "sha256:77d9314b9e186290ae6b8bfd121587795ff169cade73ba9f4973f60860dda3dc",
+                "sha256:78d79f9f760826d52ffc155f91d33a34d03d84d989906791c15196070d1b626a",
+                "sha256:7bd87846f42d54f5d19ddee234fc7d72afe84a57e2394e2e95b1bc63efaf8d16",
+                "sha256:7d62febf35707621a02e87bf4ea0ba590cc39c5c326e1fbd8a77b7e068134fb5",
+                "sha256:942af9f49c7a04214bf7739c54ae0eab1bd5dcbcb267968cb7b88e4823c43496",
+                "sha256:9562bce6deb18653594e78e3fa35e4446ccb54f5f1f24db3a7c08d059cb72ec4",
+                "sha256:99d653f3a92f35e3c768a142aa83c8c7b104a787655c51e25dca89ed778960b8",
+                "sha256:abbb361c739b1d4af5a1e92cf21325f3a0408de83aa52aaaed94dfcd664df8b1",
+                "sha256:b923b83e5a338800ae44d716b2aa22942b0d1a77261a431398ffb9703dda2722",
+                "sha256:cc3d6c031b2cbb187e572d51b6b9454cc0052e87fb2f98a1699d4a58a613bcb3",
+                "sha256:e8f11bee8b3df13cfa00c64b4ae99aef49199609342cd99bcef4d9fcd9e76267",
+                "sha256:f1f31152f3703c4f1ccbd8069b888da2c402b963aa653c914191cb9a41e69e29",
+                "sha256:f4f302ad323b8d0a4c31efe20727c1f367696b2bfd4d92a26ad974e3284ee783"
             ],
-            "version": "==3.6.4"
+            "version": "==3.6.5"
         },
         "pytest": {
             "hashes": [
-                "sha256:8214ab8446104a1d0c17fbd218ec6aac743236c6ffbe23abc038e40213c60b88",
-                "sha256:e2b2c6e1560b8f9dc8dd600b0923183fbd68ba3d9bdecde04467be6dd296a384"
+                "sha256:86a8dbf407e437351cef4dba46736e9c5a6e3c3ac71b2e942209748e76ff2086",
+                "sha256:e74466e97ac14582a8188ff4c53e6cc3810315f342f6096899332ae864c1d432"
             ],
-            "version": "==3.7.0"
+            "version": "==3.7.1"
+        },
+        "pytest-forked": {
+            "hashes": [
+                "sha256:e4500cd0509ec4a26535f7d4112a8cc0f17d3a41c29ffd4eab479d2a55b30805",
+                "sha256:f275cb48a73fc61a6710726348e1da6d68a978f0ec0c54ece5a5fae5977e5a08"
+            ],
+            "version": "==0.2"
+        },
+        "pytest-xdist": {
+            "hashes": [
+                "sha256:3308c4f6221670432d01e0b393b333d77c1fd805532e1d64450e8140855eb51b",
+                "sha256:cce08b4b7f56d34d43b365e2b3667ebb8edcf91d01c2a8fccf45c56d37e71bc1"
+            ],
+            "index": "pypi",
+            "version": "==1.22.5"
         },
         "python-dateutil": {
             "hashes": [
@@ -214,7 +244,6 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
             "version": "==2.19.1"
         },
         "s3transfer": {
@@ -236,7 +265,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
+            "markers": "python_version < '4' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.6'",
             "version": "==1.23"
         }
     },
@@ -250,10 +279,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:a48b57ede295c3188ef5c84273bc2a8eadc46e4cbb001eae0d49fb5d1fabbb19",
-                "sha256:d066cdeec5faeb51a4be5010da612680653d844b57afd86a5c8315f2f801b4cc"
+                "sha256:292fa429e69d60e4161e7612cb7cc8fa3609e2e309f80c224d93a76d5e7b58be",
+                "sha256:c7013d119ec95eb626f7a2011f0b63d0c9a095df9ad06d8507b37084eada1a8d"
             ],
-            "version": "==2.0.2"
+            "version": "==2.0.4"
         },
         "atomicwrites": {
             "hashes": [
@@ -285,24 +314,24 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:c848ae99e09f2899c5f81b8fdad90b2ef1fb7a760b13f2b1e51a345f4fd11d2b",
-                "sha256:e225d9fa3f313049547bf510a54d5f0af82f70d53fe0c0f891a0a9f8d4474681"
+                "sha256:7fdc2f6f21372572fec9df52e70b5ae11c263fe5905fc61dbd7ac3b01350cb4a",
+                "sha256:e3ac48844b5ee6adafd27f6682efdd009a9c5f70abef0b72092d039ae3050279"
             ],
-            "version": "==1.7.67"
+            "version": "==1.7.77"
         },
         "botocore": {
             "hashes": [
-                "sha256:e578f2618d0076950bcbd6ac938471310b08c292277b49092b938c59788012a6",
-                "sha256:e9eea23c566c30c69879941c4183294b7d45d8d8ff7946669364d8bb48ed0c90"
+                "sha256:bcd30fdd029f4d402b39fd52d89e90cdc26b7fb1a56e4b5778e6eff00608fd11",
+                "sha256:d9a0d504034f75341dde22a8917531071205dff92cc3f5f0962a3605951792b0"
             ],
-            "version": "==1.10.67"
+            "version": "==1.10.77"
         },
         "certifi": {
             "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
+                "sha256:4c1d68a1408dd090d2f3a869aa94c3947cc1d967821d1ed303208c9f41f0f2f4",
+                "sha256:b6e8b28b2b7e771a41ecdd12d4d43262ecab52adebbafa42c77d6b57fb6ad3a4"
             ],
-            "version": "==2018.4.16"
+            "version": "==2018.8.13"
         },
         "cffi": {
             "hashes": [
@@ -357,34 +386,35 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:21af753934f2f6d1a10fe8f4c0a64315af209ef6adeaee63ca349797d747d687",
-                "sha256:27bb401a20a838d6d0ea380f08c6ead3ccd8c9d8a0232dc9adcc0e4994576a66",
-                "sha256:29720c4253263cff9aea64585adbbe85013ba647f6e98367efff9db2d7193ded",
-                "sha256:2a35b7570d8f247889784010aac8b384fd2e4a47b33e15c4a60b45a7c1944120",
-                "sha256:42c531a6a354407f42ee07fda5c2c0dc822cf6d52744949c182f2b295fbd4183",
-                "sha256:5eb86f03f9c4f0ac2336ac5431271072ddf7ecc76b338e26366732cfac58aa19",
-                "sha256:67f7f57eae8dede577f3f7775957f5bec93edd6bdb6ce597bb5b28e1bdf3d4fb",
-                "sha256:6ec84edcbc966ae460560a51a90046503ff0b5b66157a9efc61515c68059f6c8",
-                "sha256:7ba834564daef87557e7fcd35c3c3183a4147b0b3a57314e53317360b9b201b3",
-                "sha256:7d7f084cbe1fdb82be5a0545062b59b1ad3637bc5a48612ac2eb428ff31b31ea",
-                "sha256:82409f5150e529d699e5c33fa8fd85e965104db03bc564f5f4b6a9199e591f7c",
-                "sha256:87d092a7c2a44e5f7414ab02fb4145723ebba411425e1a99773531dd4c0e9b8d",
-                "sha256:8c56ef989342e42b9fcaba7c74b446f0cc9bed546dd00034fa7ad66fc00307ef",
-                "sha256:9449f5d4d7c516a6118fa9210c4a00f34384cb1d2028672100ee0c6cce49d7f6",
-                "sha256:bc2301170986ad82d9349a91eb8884e0e191209c45f5541b16aa7c0cfb135978",
-                "sha256:c132bab45d4bd0fff1d3fe294d92b0a6eb8404e93337b3127bdec9f21de117e6",
-                "sha256:c3d945b7b577f07a477700f618f46cbc287af3a9222cd73035c6ef527ef2c363",
-                "sha256:cee18beb4c807b5c0b178f4fa2fae03cef9d51821a358c6890f8b23465b7e5d2",
-                "sha256:d01dfc5c2b3495184f683574e03c70022674ca9a7be88589c5aba130d835ea90"
+                "sha256:02602e1672b62e803e08617ec286041cc453e8d43f093a5f4162095506bc0beb",
+                "sha256:10b48e848e1edb93c1d3b797c83c72b4c387ab0eb4330aaa26da8049a6cbede0",
+                "sha256:17db09db9d7c5de130023657be42689d1a5f60502a14f6f745f6f65a6b8195c0",
+                "sha256:227da3a896df1106b1a69b1e319dce218fa04395e8cc78be7e31ca94c21254bc",
+                "sha256:2cbaa03ac677db6c821dac3f4cdfd1461a32d0615847eedbb0df54bb7802e1f7",
+                "sha256:31db8febfc768e4b4bd826750a70c79c99ea423f4697d1dab764eb9f9f849519",
+                "sha256:4a510d268e55e2e067715d728e4ca6cd26a8e9f1f3d174faf88e6f2cb6b6c395",
+                "sha256:6a88d9004310a198c474d8a822ee96a6dd6c01efe66facdf17cb692512ae5bc0",
+                "sha256:76936ec70a9b72eb8c58314c38c55a0336a2b36de0c7ee8fb874a4547cadbd39",
+                "sha256:7e3b4aecc4040928efa8a7cdaf074e868af32c58ffc9bb77e7bf2c1a16783286",
+                "sha256:8168bcb08403ef144ff1fb880d416f49e2728101d02aaadfe9645883222c0aa5",
+                "sha256:8229ceb79a1792823d87779959184a1bf95768e9248c93ae9f97c7a2f60376a1",
+                "sha256:8a19e9f2fe69f6a44a5c156968d9fc8df56d09798d0c6a34ccc373bb186cee86",
+                "sha256:8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6",
+                "sha256:be495b8ec5a939a7605274b6e59fbc35e76f5ad814ae010eb679529671c9e119",
+                "sha256:dc2d3f3b1548f4d11786616cf0f4415e25b0fbecb8a1d2cd8c07568f13fdde38",
+                "sha256:e4aecdd9d5a3d06c337894c9a6e2961898d3f64fe54ca920a72234a3de0f9cb3",
+                "sha256:e79ab4485b99eacb2166f3212218dd858258f374855e1568f728462b0e6ee0d9",
+                "sha256:f995d3667301e1754c57b04e0bae6f0fa9d710697a9f8d6712e8cca02550910f"
             ],
-            "version": "==2.3"
+            "version": "==2.3.1"
         },
         "docker": {
             "hashes": [
-                "sha256:52cf5b1c3c394f9abf897638bfc3336d6b63a0f65969d0d4d2da6d3b1d8032b6",
-                "sha256:ad077b49660b711d20f50f344f70cfae014d635ef094bf21b0d7df5f0aeedf99"
+                "sha256:6c4da20ef40e8d3eaf650f1488d91452b9a1128045481d7169fd34665ffa90ee",
+                "sha256:bc693be5a84b3b9e5aaf156068c5c0a445ee5138c638c3fbc857133bf67ebe07"
             ],
-            "version": "==3.4.1"
+            "markers": "python_version < '4' and python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.6' and python_version != '3.1.*'",
+            "version": "==3.5.0"
         },
         "docker-pycreds": {
             "hashes": [
@@ -401,6 +431,19 @@
             ],
             "version": "==0.14"
         },
+        "ecdsa": {
+            "hashes": [
+                "sha256:40d002cf360d0e035cf2cb985e1308d41aaa087cbfc135b2dc2d844296ea546c",
+                "sha256:64cf1ee26d1cde3c73c6d7d107f835fed7c6a2904aef9eac223d57ad800c43fa"
+            ],
+            "version": "==0.13"
+        },
+        "future": {
+            "hashes": [
+                "sha256:e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb"
+            ],
+            "version": "==0.16.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
@@ -414,7 +457,7 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==4.3.4"
         },
         "jinja2": {
@@ -507,18 +550,11 @@
         },
         "moto": {
             "hashes": [
-                "sha256:45d14aca2b06b0083d5e82cfd770ebca0ba77b5070aec6928670240939a78681",
-                "sha256:ee71b515ba34d64c5f625950fc995594040f793a4a106614ff108ae02c1a2896"
+                "sha256:7c86d1c3bd6362954afaded735354c11afd22037eb6736152f057a1bff0c8868",
+                "sha256:b8556c1e0cebf931a698bf7198bb3eaf2287c8c9bb4f3455ea5d2015ad8f1708"
             ],
             "index": "pypi",
-            "version": "==1.3.3"
-        },
-        "packaging": {
-            "hashes": [
-                "sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0",
-                "sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b"
-            ],
-            "version": "==17.1"
+            "version": "==1.3.4"
         },
         "pbr": {
             "hashes": [
@@ -532,7 +568,7 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==0.7.1"
         },
         "py": {
@@ -540,7 +576,7 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7'",
             "version": "==1.5.4"
         },
         "pyaml": {
@@ -556,27 +592,55 @@
             ],
             "version": "==2.18"
         },
+        "pycryptodome": {
+            "hashes": [
+                "sha256:02efa83b54371c468710ab2046ce2e254b512ebc2b1ce0d0d39a27b99c3b4b5d",
+                "sha256:08b5fe4679f0abf933cb51601c0fd1eaa0162218e5376216b52d67ec9e15fa87",
+                "sha256:08bce87c4631259ccf539b79dfa159022b5f5509068cfdc98094b6f7aed59942",
+                "sha256:0c98aa60c77418e5630c68e53ff18082e1c61f02136f3c6c06a9a456274db2cf",
+                "sha256:108652deb58d5daabf8cc1f31b821b9c9ee25101249ea6d88d09bb9de6cbeb07",
+                "sha256:111e05763f5834e4a05845ba6eff51db40d767314c9488dcc1ae7ac244b36001",
+                "sha256:14c4dab655b566b7b692bcfb9e9a48fd4a8bae18387e554f141203ae4737d263",
+                "sha256:242bc6384fc7acdcfad657921dca0d85d8a7de524463faa3b3a8d43c4285c689",
+                "sha256:248260a614fd8a3b28e26bb76064cf4d590098c9d37cd53736d8e5f5551e8260",
+                "sha256:2bc42b15c3e5dded13140a668d91cdfbec401d5e8e33bdc04eccfaddc6572d9d",
+                "sha256:2c0b45de63a904b0d995e9a82e5440f45cdd24d99566c2dd014c701d53813603",
+                "sha256:3e14dd6090dd88d4155451ced752d900a0d646c6fb74a772a5b68ab24fcb1c38",
+                "sha256:3fa6a292aa91f2be89f36844bb442a6e922a7facd82ce6a473949a08d7acb371",
+                "sha256:63de75b4639d3f916e13bfce77ea29bcc7c946a43a3ddb53131d0bda1612a704",
+                "sha256:666ef7aa4bbd3fe450aeddcb693113bd5d702938b803ae6591873b52217f36c6",
+                "sha256:69db6c222b689f746e092894c8f7b2b4e62e70bf8caf728baa93b3a40a2ecc08",
+                "sha256:76fc24aa3f2661680c590e90d716e66f5798e0c789554069483ce8644359be92",
+                "sha256:77d9314b9e186290ae6b8bfd121587795ff169cade73ba9f4973f60860dda3dc",
+                "sha256:78d79f9f760826d52ffc155f91d33a34d03d84d989906791c15196070d1b626a",
+                "sha256:7bd87846f42d54f5d19ddee234fc7d72afe84a57e2394e2e95b1bc63efaf8d16",
+                "sha256:7d62febf35707621a02e87bf4ea0ba590cc39c5c326e1fbd8a77b7e068134fb5",
+                "sha256:942af9f49c7a04214bf7739c54ae0eab1bd5dcbcb267968cb7b88e4823c43496",
+                "sha256:9562bce6deb18653594e78e3fa35e4446ccb54f5f1f24db3a7c08d059cb72ec4",
+                "sha256:99d653f3a92f35e3c768a142aa83c8c7b104a787655c51e25dca89ed778960b8",
+                "sha256:abbb361c739b1d4af5a1e92cf21325f3a0408de83aa52aaaed94dfcd664df8b1",
+                "sha256:b923b83e5a338800ae44d716b2aa22942b0d1a77261a431398ffb9703dda2722",
+                "sha256:cc3d6c031b2cbb187e572d51b6b9454cc0052e87fb2f98a1699d4a58a613bcb3",
+                "sha256:e8f11bee8b3df13cfa00c64b4ae99aef49199609342cd99bcef4d9fcd9e76267",
+                "sha256:f1f31152f3703c4f1ccbd8069b888da2c402b963aa653c914191cb9a41e69e29",
+                "sha256:f4f302ad323b8d0a4c31efe20727c1f367696b2bfd4d92a26ad974e3284ee783"
+            ],
+            "version": "==3.6.5"
+        },
         "pylint": {
             "hashes": [
-                "sha256:0edfec21270725c5aa8e8d8d06ef5666f766e0e748ed2f1ab23624727303b935",
-                "sha256:4cadcaa4f1fb19123d4baa758d9fbe6286c5b3aa513af6ea42a2d51d405db205"
+                "sha256:1d6d3622c94b4887115fe5204982eee66fdd8a951cf98635ee5caee6ec98c3ec",
+                "sha256:31142f764d2a7cd41df5196f9933b12b7ee55e73ef12204b648ad7e556c119fb"
             ],
             "index": "pypi",
-            "version": "==2.1.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04",
-                "sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010"
-            ],
-            "version": "==2.2.0"
+            "version": "==2.1.1"
         },
         "pytest": {
             "hashes": [
-                "sha256:8214ab8446104a1d0c17fbd218ec6aac743236c6ffbe23abc038e40213c60b88",
-                "sha256:e2b2c6e1560b8f9dc8dd600b0923183fbd68ba3d9bdecde04467be6dd296a384"
+                "sha256:86a8dbf407e437351cef4dba46736e9c5a6e3c3ac71b2e942209748e76ff2086",
+                "sha256:e74466e97ac14582a8188ff4c53e6cc3810315f342f6096899332ae864c1d432"
             ],
-            "version": "==3.7.0"
+            "version": "==3.7.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -585,6 +649,13 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==2.7.3"
+        },
+        "python-jose": {
+            "hashes": [
+                "sha256:391f860dbe274223d73dd87de25e4117bf09e8fe5f93a417663b1f2d7b591165",
+                "sha256:3b35cdb0e55a88581ff6d3f12de753aa459e940b50fe7ca5aa25149bc94cb37b"
+            ],
+            "version": "==2.0.2"
         },
         "pytz": {
             "hashes": [
@@ -614,7 +685,6 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
             "version": "==2.19.1"
         },
         "responses": {
@@ -640,11 +710,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:4df108a1fcc93a7ee4ac97e1a3a1fc3d41ddd22445d518976604e2ef05025280",
-                "sha256:9f0cbcc36e08c2c4ae90d02d3d1f9a62231f974bcbc1df85e8045946d8261059"
+                "sha256:37cf240781b662fb790710c6998527e65ca6851eace84d1595ee71f7af4e85f7",
+                "sha256:eb61aa5bcce65325538686f09848f04ef679b5cd9b83cc491272099b28739600"
             ],
             "index": "pypi",
-            "version": "==3.1.2"
+            "version": "==3.2.1"
         },
         "typed-ast": {
             "hashes": [
@@ -672,22 +742,15 @@
                 "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
                 "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
             ],
+            "markers": "python_version < '3.7' and implementation_name == 'cpython'",
             "version": "==1.1.0"
-        },
-        "typing": {
-            "hashes": [
-                "sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf",
-                "sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8",
-                "sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2"
-            ],
-            "version": "==3.6.4"
         },
         "urllib3": {
             "hashes": [
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version < '4' and python_version != '3.2.*' and python_version != '3.0.*' and python_version != '3.3.*'",
+            "markers": "python_version < '4' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.6'",
             "version": "==1.23"
         },
         "virtualenv": {
@@ -695,15 +758,15 @@
                 "sha256:2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669",
                 "sha256:ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.2.*'",
+            "markers": "python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==16.0.0"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:18f1170e6a1b5463986739d9fd45c4308b0d025c1b2f9b88788d8f69e8a5eb4a",
-                "sha256:db70953ae4a064698b27ae56dcad84d0ee68b7b43cb40940f537738f38f510c1"
+                "sha256:728f405ba502e39fbd8a5903ca55161749ee77633caedc7b11222d83b344bb7c",
+                "sha256:bf36b4b4726cab3bf93e842deef3c5bf12bd9c134e45e9a852c76140309f5ae2"
             ],
-            "version": "==0.48.0"
+            "version": "==0.49.0"
         },
         "werkzeug": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ tox
 To run tests against GCE and AWS, run:
 
 ```
-pytest -m "gce" --fulltrace
-pytest -m "aws" --fulltrace
+tox -e gce
+tox -e aws
 ```
 
 For GCE, you must set `BUTTER_GCE_USER_ID`, `BUTTER_GCE_CREDENTIALS_PATH`, and

--- a/butter/providers/gce/impl/firewalls.py
+++ b/butter/providers/gce/impl/firewalls.py
@@ -1,4 +1,3 @@
-# pylint: disable=missing-docstring
 """
 Firewalls Impl
 
@@ -9,27 +8,28 @@ from butter.providers.gce.log import logger
 
 # pylint: disable=too-few-public-methods
 class Firewalls:
+    """
+    Class to manage GCE firewalls.
+    """
+
     def __init__(self, driver):
         self.driver = driver
 
-    def cleanup_orphaned_firewalls(self):
+    def delete_firewall(self, network_name, subnetwork_name):
+        """
+        Delete the firewall corresponding to the service described by "network_name" and
+        "subnetwork_name".
+        """
         firewalls = self.driver.ex_list_firewalls()
-        nodes = self.driver.list_nodes()
+        tag = "%s-%s" % (network_name, subnetwork_name)
         for firewall in firewalls:
-            used = False
-            for node in nodes:
-                if not node.extra["tags"]:
-                    pass
-                for tag in node.extra["tags"]:
-                    if not firewall.source_tags and not firewall.target_tags:
-                        used = True
-                        continue
-                    if firewall.source_tags:
-                        if tag in firewall.source_tags:
-                            used = True
-                    if firewall.target_tags:
-                        if tag in firewall.target_tags:
-                            used = True
-            if not used:
-                logger.info("Deleting unused firewall: %s", firewall)
-                self.driver.ex_destroy_firewall(firewall)
+            if not firewall.source_tags and not firewall.target_tags:
+                continue
+            if firewall.source_tags:
+                if tag in firewall.source_tags:
+                    logger.info("Deleting firewall %s because of source tag: %s", firewall, tag)
+                    self.driver.ex_destroy_firewall(firewall)
+            if firewall.target_tags:
+                if tag in firewall.target_tags:
+                    logger.info("Deleting firewall %s because of target tag: %s", firewall, tag)
+                    self.driver.ex_destroy_firewall(firewall)

--- a/example-blueprints/gce-apache/blueprint.yml
+++ b/example-blueprints/gce-apache/blueprint.yml
@@ -7,7 +7,7 @@ placement:
 
 instance:
   public_ip: True
-  memory: 4GB
+  memory: 1GB
   cpus: 1
   gpu: false
   disks:

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ REQUIRED = [
 # What packages are required for this module to be tested?
 TESTS_REQUIRED = [
     'pytest',
+    'pytest-xdist',
     'moto',
     'tox',
     'pylint'

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -1,3 +1,6 @@
+"""
+Tests for blueprint reader.
+"""
 import os
 import pytest
 from butter.util.blueprint import InstancesBlueprint
@@ -22,6 +25,9 @@ OPTIONAL_NOT_SET = """# Blueprint Test
 # optional_var: """
 
 def test_blueprint():
+    """
+    Blueprint reader tests.
+    """
     instances_blueprint = InstancesBlueprint(INSTANCES_BLUEPRINT,
                                              {"list_var": ["foo"],
                                               "other_var": ["bar"]})

--- a/tests/test_blueprint_tester.py
+++ b/tests/test_blueprint_tester.py
@@ -1,3 +1,6 @@
+"""
+Tests for blueprint test framework.
+"""
 import os
 import pytest
 from moto import mock_ec2, mock_autoscaling
@@ -13,6 +16,9 @@ from butter.testutils.blueprint_tester import get_state
 BLUEPRINT_DIR = os.path.join(os.path.dirname(__file__), "blueprint_tester_fixture")
 
 def run_blueprint_tester_test(provider, credentials):
+    """
+    Test blueprint test framework with the given provider.
+    """
 
     # Get the client for this test
     client = butter.Client(provider, credentials)
@@ -60,4 +66,7 @@ def run_blueprint_tester_test(provider, credentials):
 @mock_autoscaling
 @pytest.mark.mock_aws
 def test_blueprint_tester_mock():
+    """
+    Test blueprint test framework against moto (mock aws).
+    """
     run_blueprint_tester_test(provider="aws", credentials={})

--- a/tests/test_instance_fitter.py
+++ b/tests/test_instance_fitter.py
@@ -1,3 +1,6 @@
+"""
+Test instance fitter.
+"""
 import os
 import pytest
 import butter
@@ -10,6 +13,9 @@ LARGE_INSTANCE_BLUEPRINT = os.path.join(BLUEPRINTS_DIR, "instance-fitter-large.y
 
 
 def run_instance_fitter_test(provider, credentials):
+    """
+    Test that we get the proper instance sizes for the given provider.
+    """
 
     # Get the client for this test
     client = butter.Client(provider, credentials)
@@ -24,10 +30,16 @@ def run_instance_fitter_test(provider, credentials):
 
 @pytest.mark.aws
 def test_instance_fitter_aws():
+    """
+    Test instance fitter with AWS and global configuration.
+    """
     run_instance_fitter_test(provider="aws", credentials={})
 
 @pytest.mark.gce
 def test_instance_fitter_gce():
+    """
+    Test instance fitter with GCE and below environment configuration.
+    """
     run_instance_fitter_test(provider="gce", credentials={
         "user_id": os.environ['BUTTER_GCE_USER_ID'],
         "key": os.environ['BUTTER_GCE_CREDENTIALS_PATH'],

--- a/tests/test_netgraph.py
+++ b/tests/test_netgraph.py
@@ -1,45 +1,55 @@
+"""
+Test conversions between different firewall representations.
+"""
 from butter.util import netgraph
 
-net = {
-        "0": {
-            "1": [{
-                "protocol": "tcp",
-                "port": "443"
-                }]
-            },
-        "external": {
-            "1": [{
-                "protocol": "tcp",
-                "port": "443"
-                }]
-            }
-        }
-
-firewalls = {
-        "0": [{
-            "source": "1",
-            "protocol": "tcp",
-            "port": "443",
-            "type": "egress"
-            }],
+NET = {
+    "0": {
         "1": [{
+            "protocol": "tcp",
+            "port": "443"
+            }]
+        },
+    "external": {
+        "1": [{
+            "protocol": "tcp",
+            "port": "443"
+            }]
+        }
+    }
+
+FIREWALLS = {
+    "0": [{
+        "source": "1",
+        "protocol": "tcp",
+        "port": "443",
+        "type": "egress"
+        }],
+    "1": [
+        {
             "source": "0",
             "protocol": "tcp",
             "port": "443",
             "type": "ingress"
-            },
-            {
+        },
+        {
             "source": "external",
             "protocol": "tcp",
             "port": "443",
             "type": "ingress"
-            }]
-        }
+        }]
+    }
 
 
 def test_net_to_firewalls():
-    assert firewalls == netgraph.net_to_firewalls(net)
+    """
+    Test conversion from a graph based to a list based format.
+    """
+    assert FIREWALLS == netgraph.net_to_firewalls(NET)
 
 
 def test_firewalls_to_net():
-    assert net == netgraph.firewalls_to_net(firewalls)
+    """
+    Test conversion from a list based to a graph based format.
+    """
+    assert NET == netgraph.firewalls_to_net(FIREWALLS)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,9 +1,13 @@
+"""
+Tests for network management.
+"""
 import ipaddress
 import os
 import pytest
 from moto import mock_ec2
 
 import butter
+from butter.testutils.blueprint_tester import generate_unique_name
 
 EXAMPLE_BLUEPRINTS_DIR = os.path.join(os.path.dirname(__file__),
                                       "..",
@@ -13,32 +17,34 @@ NETWORK_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
 
 
 def run_network_test(provider, credentials):
+    """
+    Test network management on the given provider.
+    """
 
     # Get the client for this test
     client = butter.Client(provider, credentials)
 
+    # Get somewhat unique network names
+    network1 = generate_unique_name("network1")
+    network2 = generate_unique_name("network2")
+
     # Create two private cloud networks
-    original_count = len(client.network.list()["Named"])
-    network1_id = client.network.create(name="network1",
+    network1_id = client.network.create(name=network1,
                                         blueprint=NETWORK_BLUEPRINT)["Id"]
-    assert len(client.network.list()["Named"]) == original_count + 1
-    # TODO: this is an AWS specific concept, figure out a more generic way to
-    # deal with this.
     inventories = [butter.providers.aws.inventory.native]
-    network2_id = client.network.create(name="network2",
+    network2_id = client.network.create(name=network2,
                                         blueprint=NETWORK_BLUEPRINT,
                                         inventories=inventories
                                         )["Id"]
-    assert len(client.network.list()["Named"]) == original_count + 2
     assert network2_id != network1_id
 
     # Make sure we can discover them again
-    assert client.network.discover("network1")["Id"] == network1_id
-    assert client.network.discover("network2")["Id"] == network2_id
+    assert client.network.discover(network1)["Id"] == network1_id
+    assert client.network.discover(network2)["Id"] == network2_id
 
     # Make sure the CIDR blocks do not overlap
-    network1_cidr_raw = client.network.discover("network1")["CidrBlock"]
-    network2_cidr_raw = client.network.discover("network2")["CidrBlock"]
+    network1_cidr_raw = client.network.discover(network1)["CidrBlock"]
+    network2_cidr_raw = client.network.discover(network2)["CidrBlock"]
     # Skip this if the CIDR blocks are "N/A", since google compute does not
     # have the concept of CIDRs for VPCs.
     if network1_cidr_raw == "N/A":
@@ -49,27 +55,34 @@ def run_network_test(provider, credentials):
         assert not network1_cidr.overlaps(network2_cidr)
 
     # Destroy them and make sure they no longer exist
-    client.network.destroy("network1")
-    assert len(client.network.list()["Named"]) == original_count + 1
-    client.network.destroy("network2")
-    assert len(client.network.list()["Named"]) == original_count + 0
-    assert not client.network.discover("network1")
-    assert not client.network.discover("network2")
+    client.network.destroy(network1)
+    client.network.destroy(network2)
+    assert not client.network.discover(network1)
+    assert not client.network.discover(network2)
 
 
 @mock_ec2
 @pytest.mark.mock_aws
 def test_network_mock():
+    """
+    Run tests using the mock aws driver (moto).
+    """
     run_network_test(provider="aws", credentials={})
 
 
 @pytest.mark.aws
 def test_network_aws():
+    """
+    Run tests against real AWS (using global configuration).
+    """
     run_network_test(provider="aws", credentials={})
 
 
 @pytest.mark.gce
 def test_network_gce():
+    """
+    Run tests against real GCE (environment variables below must be set).
+    """
     run_network_test(provider="gce", credentials={
         "user_id": os.environ['BUTTER_GCE_USER_ID'],
         "key": os.environ['BUTTER_GCE_CREDENTIALS_PATH'],

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,7 +1,11 @@
+"""
+Test for path management.
+"""
 import os
 import pytest
 from moto import mock_ec2, mock_autoscaling, mock_elb, mock_route53
 import butter
+from butter.testutils.blueprint_tester import generate_unique_name
 
 EXAMPLE_BLUEPRINTS_DIR = os.path.join(os.path.dirname(__file__),
                                       "..",
@@ -11,46 +15,50 @@ NETWORK_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
 SUBNETWORK_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
                                     "subnetwork", "blueprint.yml")
 
-# TODO: Find a way to consolidate these.  The main issue is that the base
-# images have different names in different providers.
 AWS_SERVICE_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
                                      "aws-nginx", "blueprint.yml")
 GCE_SERVICE_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
                                      "gce-apache", "blueprint.yml")
 
 def run_paths_test(provider, credentials):
+    """
+    Test that the path management works against the given provider.
+    """
 
     # Get the client for this test
     client = butter.Client(provider, credentials)
 
+    # Get a somewhat unique network name
+    network_name = generate_unique_name("unittest")
+
     # Provision all the resources
-    client.network.create("unittest", blueprint=NETWORK_BLUEPRINT)
+    client.network.create(network_name, blueprint=NETWORK_BLUEPRINT)
     if provider == "aws":
-        client.instances.create("unittest", "web-lb", AWS_SERVICE_BLUEPRINT)
-        client.instances.create("unittest", "web", AWS_SERVICE_BLUEPRINT)
+        client.instances.create(network_name, "web-lb", AWS_SERVICE_BLUEPRINT)
+        client.instances.create(network_name, "web", AWS_SERVICE_BLUEPRINT)
     else:
         assert provider == "gce"
-        client.instances.create("unittest", "web-lb", GCE_SERVICE_BLUEPRINT)
-        client.instances.create("unittest", "web", GCE_SERVICE_BLUEPRINT)
+        client.instances.create(network_name, "web-lb", GCE_SERVICE_BLUEPRINT)
+        client.instances.create(network_name, "web", GCE_SERVICE_BLUEPRINT)
 
-    assert not client.paths.has_access("unittest", "web-lb", "web", 80)
-    assert not client.paths.internet_accessible("unittest", "web-lb", 80)
+    assert not client.paths.has_access(network_name, "web-lb", "web", 80)
+    assert not client.paths.internet_accessible(network_name, "web-lb", 80)
 
     # Deal with networking
-    client.paths.expose("unittest", "web-lb", 80)
-    client.paths.add("unittest", "web-lb", "web", 80)
+    client.paths.expose(network_name, "web-lb", 80)
+    client.paths.add(network_name, "web-lb", "web", 80)
     client.paths.list()
     client.graph()
 
-    assert client.paths.has_access("unittest", "web-lb", "web", 80)
-    assert client.paths.internet_accessible("unittest", "web-lb", 80)
+    assert client.paths.has_access(network_name, "web-lb", "web", 80)
+    assert client.paths.internet_accessible(network_name, "web-lb", 80)
 
-    client.paths.remove("unittest", "web-lb", "web", 80)
-    assert not client.paths.has_access("unittest", "web-lb", "web", 80)
+    client.paths.remove(network_name, "web-lb", "web", 80)
+    assert not client.paths.has_access(network_name, "web-lb", "web", 80)
 
-    client.instances.destroy("unittest", "web-lb")
-    client.instances.destroy("unittest", "web")
-    client.network.destroy("unittest")
+    client.instances.destroy(network_name, "web-lb")
+    client.instances.destroy(network_name, "web")
+    client.network.destroy(network_name)
 
 @mock_ec2
 @mock_elb
@@ -58,14 +66,23 @@ def run_paths_test(provider, credentials):
 @mock_route53
 @pytest.mark.mock_aws
 def test_paths_mock():
+    """
+    Run tests using the mock aws driver (moto).
+    """
     run_paths_test(provider="aws", credentials={})
 
 @pytest.mark.aws
 def test_paths_aws():
+    """
+    Run tests against real AWS (using global configuration).
+    """
     run_paths_test(provider="aws", credentials={})
 
 @pytest.mark.gce
 def test_paths_gce():
+    """
+    Run tests against real GCE (environment variables below must be set).
+    """
     run_paths_test(provider="gce", credentials={
         "user_id": os.environ['BUTTER_GCE_USER_ID'],
         "key": os.environ['BUTTER_GCE_CREDENTIALS_PATH'],

--- a/tests/test_storage_size_parser.py
+++ b/tests/test_storage_size_parser.py
@@ -1,8 +1,16 @@
+"""
+Test storage size parser.
+
+This was a helper to convert a size string to bytes.
+"""
 import pytest
 from butter.util.storage_size_parser import parse_storage_size
 
 
 def test_storage_size_parser():
+    """
+    Test that our parser properly converts the given strings to bytes.
+    """
     assert parse_storage_size("10 MiB") == 10485760
     assert parse_storage_size("10MB") == 10000000
     with pytest.raises(SyntaxError,

--- a/tests/test_subnet_generator.py
+++ b/tests/test_subnet_generator.py
@@ -1,8 +1,13 @@
-import ipaddress
+"""
+Test helper to carve subnets out of a CIDR,
+"""
 from butter.util.subnet_generator import generate_subnets
 
 
 def test_generate_subnets():
+    """
+    Test that we get the right subnets back given parent cidr and existing subnets.
+    """
     subnets = generate_subnets("10.0.0.0/8",
                                ["10.0.0.0/9", "10.128.0.0/10"], 10, 1)
     assert list(subnets) == ["10.192.0.0/10"]

--- a/tests/test_subnetwork.py
+++ b/tests/test_subnetwork.py
@@ -1,8 +1,12 @@
+"""
+Tests for subnetwork management.
+"""
 import os
 import pytest
 from moto import mock_ec2
 
 import butter
+from butter.testutils.blueprint_tester import generate_unique_name
 
 EXAMPLE_BLUEPRINTS_DIR = os.path.join(os.path.dirname(__file__),
                                       "..",
@@ -13,13 +17,19 @@ SUBNETWORK_BLUEPRINT = os.path.join(EXAMPLE_BLUEPRINTS_DIR,
                                     "subnetwork", "blueprint.yml")
 
 def run_subnetwork_test(provider, credentials):
+    """
+    Test subnetwork management on the given provider.
+    """
 
     # Get the client for this test
     client = butter.Client(provider, credentials)
 
+    # Get a somewhat unique network name
+    network_name = generate_unique_name("unittestsubnet")
+
     # Provision public and private networks
-    client.network.create("unittestsubnet", blueprint=NETWORK_BLUEPRINT)
-    public_subnets = client.subnetwork.create("unittestsubnet", "public",
+    client.network.create(network_name, blueprint=NETWORK_BLUEPRINT)
+    public_subnets = client.subnetwork.create(network_name, "public",
                                               blueprint=SUBNETWORK_BLUEPRINT)
     # GCE doesn't do subnet based availablity zones
     if public_subnets[0]["AvailabilityZone"] == "N/A":
@@ -27,43 +37,52 @@ def run_subnetwork_test(provider, credentials):
     else:
         expected_subnet_count = 3
     assert len(public_subnets) == expected_subnet_count
-    private_subnets = client.subnetwork.create("unittestsubnet", "private",
+    private_subnets = client.subnetwork.create(network_name, "private",
                                                blueprint=SUBNETWORK_BLUEPRINT)
     assert len(private_subnets) == expected_subnet_count
 
     # Make sure I can discover them based on service name
-    assert len(client.subnetwork.discover("unittestsubnet", "public")) == expected_subnet_count
-    assert len(client.subnetwork.discover("unittestsubnet", "private")) == expected_subnet_count
+    assert len(client.subnetwork.discover(network_name, "public")) == expected_subnet_count
+    assert len(client.subnetwork.discover(network_name, "private")) == expected_subnet_count
 
     # Make sure they show up when I list them
     subnet_info = client.subnetwork.list()
-    assert len(subnet_info["unittestsubnet"]["public"]) == expected_subnet_count
-    assert len(subnet_info["unittestsubnet"]["private"]) == expected_subnet_count
+    assert len(subnet_info[network_name]["public"]) == expected_subnet_count
+    assert len(subnet_info[network_name]["private"]) == expected_subnet_count
 
     # Now destroy them and make sure everything gets cleaned up
-    client.subnetwork.destroy("unittestsubnet", "public")
-    public_subnets = client.subnetwork.discover("unittestsubnet", "public")
+    client.subnetwork.destroy(network_name, "public")
+    public_subnets = client.subnetwork.discover(network_name, "public")
     assert not public_subnets
-    assert client.network.discover("unittestsubnet")
+    assert client.network.discover(network_name)
 
-    client.subnetwork.destroy("unittestsubnet", "private")
-    private_subnets = client.subnetwork.discover("unittestsubnet", "private")
+    client.subnetwork.destroy(network_name, "private")
+    private_subnets = client.subnetwork.discover(network_name, "private")
     assert not private_subnets
-    client.network.destroy("unittestsubnet")
-    assert not client.network.discover("unittestsubnet")
+    client.network.destroy(network_name)
+    assert not client.network.discover(network_name)
 
 
 @mock_ec2
 @pytest.mark.mock_aws
 def test_subnetwork_mock():
+    """
+    Run tests using the mock aws driver (moto).
+    """
     run_subnetwork_test(provider="aws", credentials={})
 
 @pytest.mark.aws
 def test_subnetwork_aws():
+    """
+    Run tests against real AWS (using global configuration).
+    """
     run_subnetwork_test(provider="aws", credentials={})
 
 @pytest.mark.gce
 def test_subnetwork_gce():
+    """
+    Run tests against real GCE (environment variables below must be set).
+    """
     run_subnetwork_test(provider="gce", credentials={
         "user_id": os.environ['BUTTER_GCE_USER_ID'],
         "key": os.environ['BUTTER_GCE_CREDENTIALS_PATH'],

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,24 @@ envlist = py36
 
 commands =
     pip install -e ".[testing]"
-    pylint butter
-    pytest -m "not gce and not aws" --fulltrace
+    pylint --jobs=4 butter
+    pylint --jobs=4 tests --disable duplicate-code
+    pytest -n 4 -m "not gce and not aws" --fulltrace
+
+[testenv:aws]
+
+commands =
+    pip install -e ".[testing]"
+    pylint --jobs=4 butter
+    pylint --jobs=4 tests --disable duplicate-code
+    pytest -n 2 -m aws --fulltrace
+
+[testenv:gce]
+
+passenv = BUTTER_GCE_USER_ID BUTTER_GCE_CREDENTIALS_PATH BUTTER_GCE_PROJECT_NAME
+
+commands =
+    pip install -e ".[testing]"
+    pylint --jobs=4 butter
+    pylint --jobs=4 tests --disable duplicate-code
+    pytest -n 8 -m gce --fulltrace


### PR DESCRIPTION
Use pytest-xdist to run tests in parallel.  This is especially relevant
for the remote tests.

Also now run the linter on the tests, since a simple lint error could be
a big time sink given how long these take to run (order of magnitude 10
minutes).

AWS returns timeouts and connection resets if I try to do too many
things in parallel, but that's a future investigation.  For now I only
set the number of cores to 2 for that test.

There were also some issues with the way firewalls were destroyed and
the way instances were discovered in GCE that caused some test failures,
so this commit fixes those.

Fixes: https://github.com/sverch/butter/issues/16