### PR TITLE
Consolidate add and expose in paths API

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,14 @@ client.instances.destroy("dev", "public")
 ### Paths (Firewalls)
 
 ```
-client.paths.expose("dev", "public", 80)
-client.paths.add("dev", "public", "private", 80)
+from butter.types.networking import Service, CidrBlock
+public_service = Service("dev", "public")
+private_service = Service("dev", "private")
+internet = CidrBlock("0.0.0.0/0")
+client.paths.add(public_service, private_service, 80)
+client.paths.add(internet, public_service, 443)
 client.paths.list()
+client.graph()
 ```
 
 ### Prototype UI
@@ -103,7 +108,7 @@ client.paths.list()
 Get a summary in the form of a graphviz compatible dot file by running:
 
 ```
-client.paths.graph()
+client.graph()
 ```
 
 To generate the vizualizations, run:

--- a/butter/providers/gce/paths.py
+++ b/butter/providers/gce/paths.py
@@ -4,8 +4,13 @@ Butter Paths on GCE
 This is a the GCE implmentation for the paths API, a high level interface to add routes between
 services, doing the conversion to firewalls and firewall rules.
 """
+import ipaddress
+from libcloud.common.google import ResourceNotFoundError
 from butter.providers.gce.driver import get_gce_driver
 from butter.providers.gce.log import logger
+from butter.types.networking import Service, CidrBlock
+from butter.util.exceptions import DisallowedOperationException
+from butter.util.public_blocks import get_public_blocks
 
 
 class PathsClient:
@@ -31,30 +36,118 @@ class PathsClient:
                                               source_ranges=["0.0.0.0/0"],
                                               target_tags=[target_tag])
 
-    def add(self, network, from_name, to_name, port):
+    # pylint: disable=no-self-use
+    def _validate_args(self, source, destination):
+        if (not isinstance(source, Service) and not isinstance(destination, Service) and
+                not isinstance(source, CidrBlock) and not isinstance(destination, CidrBlock)):
+            raise DisallowedOperationException(
+                "Source and destination can only be a butter.types.networking.Service object or a "
+                "butter.types.networking.CidrBlock object")
+
+        if not isinstance(destination, Service) and not isinstance(source, Service):
+            raise DisallowedOperationException(
+                "Either destination or source must be a butter.types.networking.Service object")
+
+        if (isinstance(source, Service) and isinstance(destination, Service) and
+                source.network_name != destination.network_name):
+            raise DisallowedOperationException(
+                "Destination and source must be in the same network if specified as services")
+
+    def _extract_service_info(self, source, destination):
+        """
+        Helper to extract the necessary information from the source and destination arguments.
+        """
+        self._validate_args(source, destination)
+        src_tags = []
+        dest_tags = []
+        src_ranges = []
+        dest_ranges = []
+        if isinstance(source, Service):
+            src_tags.append("%s-%s" % (source.network_name, source.service_name))
+        if isinstance(source, CidrBlock):
+            src_ranges.append(str(source.cidr_block))
+        if isinstance(destination, Service):
+            dest_tags.append("%s-%s" % (destination.network_name, destination.service_name))
+        if isinstance(destination, CidrBlock):
+            dest_ranges.append(str(destination.cidr_block))
+        return src_tags, dest_tags, src_ranges, dest_ranges
+
+    def add(self, source, destination, port):
         """
         Add path between two services on a given port.
         """
-        logger.info('Adding path from %s to %s in network %s on port %s',
-                    from_name, to_name, network, port)
+        logger.info('Adding path from %s to %s on port %s', source, destination, port)
         rules = [{"IPProtocol": "tcp", "ports": [port]}]
-        firewall_name = "bu-%s-%s-%s-%s" % (network, from_name, to_name, port)
-        source_tag = "%s-%s" % (network, from_name)
-        target_tag = "%s-%s" % (network, to_name)
-        return self.driver.ex_create_firewall(firewall_name, allowed=rules,
-                                              network=network,
-                                              source_tags=[source_tag],
-                                              target_tags=[target_tag])
+        src_tags, dest_tags, src_ranges, _ = self._extract_service_info(
+            source, destination)
+        firewall_name = "bu-%s-%s-%s" % (destination.network_name, destination.service_name, port)
+        try:
+            firewall = self.driver.ex_get_firewall(firewall_name)
+            if isinstance(source, CidrBlock):
+                if not firewall.source_ranges:
+                    firewall.source_ranges = []
+                firewall.source_ranges.append(str(source.cidr_block))
+                logger.info(firewall.source_ranges)
+            if isinstance(source, Service):
+                if not firewall.source_tags:
+                    firewall.source_tags = []
+                source_tag = "%s-%s" % (source.network_name, source.service_name)
+                firewall.source_tags.append(source_tag)
+                logger.info(firewall.source_tags)
+            return self.driver.ex_update_firewall(firewall)
+        except ResourceNotFoundError:
+            logger.info("Firewall %s not found, creating.", firewall_name)
+            return self.driver.ex_create_firewall(firewall_name, allowed=rules,
+                                                  network=destination.network_name,
+                                                  source_ranges=src_ranges,
+                                                  source_tags=src_tags,
+                                                  target_tags=dest_tags)
 
-    def remove(self, network, from_name, to_name, port):
+    def remove(self, source, destination, port):
         """
         Remove path between two services on a given port.
         """
-        logger.info('Removing path from %s to %s in network %s on port %s',
-                    from_name, to_name, network, port)
-        firewall_name = "bu-%s-%s-%s-%s" % (network, from_name, to_name, port)
-        return self.driver.ex_destroy_firewall(
-            self.driver.ex_get_firewall(firewall_name))
+        logger.info('Removing path from %s to %s on port %s',
+                    source, destination, port)
+
+        firewall_name = "bu-%s-%s-%s" % (destination.network_name, destination.service_name, port)
+
+        def remove_from_ranges(to_remove, address_ranges):
+            logger.info("Removing %s from %s", to_remove, address_ranges)
+            resulting_ranges = []
+            if not address_ranges:
+                return None
+            for address_range in address_ranges:
+                remove_net = ipaddress.IPv4Network(to_remove)
+                address_range_network = ipaddress.IPv4Network(address_range)
+                if remove_net.overlaps(address_range_network):
+                    if remove_net.prefixlen > address_range_network.prefixlen:
+                        new_range_networks = address_range_network.address_exclude(remove_net)
+                        resulting_ranges.extend([str(new_range_network) for new_range_network
+                                                 in new_range_networks])
+                else:
+                    resulting_ranges.extend([str(address_range_network)])
+            logger.info("New ranges: %s", resulting_ranges)
+            return resulting_ranges
+
+        try:
+            firewall = self.driver.ex_get_firewall(firewall_name)
+            if isinstance(source, CidrBlock):
+                firewall.source_ranges = remove_from_ranges(source.cidr_block,
+                                                            firewall.source_ranges)
+            else:
+                source_tag = "%s-%s" % (source.network_name, source.service_name)
+                if firewall.source_tags:
+                    firewall.source_tags = [tag for tag in firewall.source_tags
+                                            if tag != source_tag]
+        except ResourceNotFoundError:
+            logger.info("Firewall %s doesn't exist", firewall_name)
+            return None
+
+        # We need this because the default is to add "0.0.0.0/0" if these aren't set, which is bad.
+        if not firewall.source_tags and not firewall.source_ranges:
+            return self.driver.ex_destroy_firewall(firewall)
+        return self.driver.ex_update_firewall(firewall)
 
     def list(self):
         """
@@ -103,31 +196,59 @@ class PathsClient:
                                           target_range, firewall)
         return fw_info
 
-    def internet_accessible(self, network_name, subnetwork_name, port):
+    def internet_accessible(self, service, port):
         """
         Return true if the given network is internet accessible.
         """
-        paths = self.list()
-        if network_name in paths:
-            if "0.0.0.0/0" in paths[network_name]:
-                if subnetwork_name in paths[network_name]["0.0.0.0/0"]:
-                    for path in paths[network_name]["0.0.0.0/0"][subnetwork_name]:
-                        if int(path["port"]) == int(port):
-                            return True
+        for public_block in get_public_blocks():
+            if self.has_access(CidrBlock(public_block), service, port):
+                return True
         return False
 
-    def has_access(self, network, from_name, to_name, port):
+    def has_access(self, source, destination, port):
         """
         Return true if there's a path between the services.
         """
-        logger.info('Looking for path from %s to %s on port %s in network %s',
-                    from_name, to_name, 80, network)
+        logger.info('Looking for path from %s to %s on port %s', source, destination, 80)
+        self._validate_args(source, destination)
         paths = self.list()
         logger.info('Found paths %s', paths)
-        if network in paths:
-            if from_name in paths[network]:
-                if to_name in paths[network][from_name]:
-                    for path in paths[network][from_name][to_name]:
+
+        def cidr_block_access(source, network_name, destination_name, paths):
+            cidr_block = str(source.cidr_block)
+            for allowed_cidr, destination_info in paths[network_name].items():
+
+                try:
+                    ipaddress.IPv4Network(allowed_cidr)
+                except ipaddress.AddressValueError as address_value_error:
+                    logger.debug('Cannot parse source as CIDR block: %s', address_value_error)
+                    continue
+
+                if (ipaddress.IPv4Network(cidr_block).overlaps(
+                        ipaddress.IPv4Network(allowed_cidr))):
+                    if destination_name in destination_info:
+                        for path in destination_info[destination_name]:
+                            if int(path["port"]) == int(port):
+                                return True
+            return False
+
+        def service_access(source, network_name, destination_name, paths):
+            source_name = source.service_name
+            if source_name in paths[network_name]:
+                if destination_name in paths[network_name][source_name]:
+                    for path in paths[network_name][source_name][destination_name]:
                         if int(path["port"]) == int(port):
                             return True
+            return False
+
+
+        destination_name = destination.service_name
+        network_name = destination.network_name
+        if network_name in paths:
+            if (isinstance(source, Service) and
+                    service_access(source, network_name, destination_name, paths)):
+                return True
+            if (isinstance(source, CidrBlock) and
+                    cidr_block_access(source, network_name, destination_name, paths)):
+                return True
         return False

--- a/butter/types/__init__.py
+++ b/butter/types/__init__.py
@@ -1,0 +1,4 @@
+"""
+Typed objects for user facing APIs.  Should be only simple data objects.
+"""
+from butter.types import networking

--- a/butter/types/networking.py
+++ b/butter/types/networking.py
@@ -1,0 +1,29 @@
+"""
+Types related to networking.
+"""
+
+import ipaddress
+
+# pylint: disable=too-few-public-methods
+class CidrBlock:
+    """
+    Simple container to hold a CIDR network block.
+    """
+    def __init__(self, cidr_block):
+        self.cidr_block = ipaddress.IPv4Network(cidr_block)
+
+    # https://stackoverflow.com/questions/1436703/difference-between-str-and-repr#2626364
+    def __repr__(self):
+        return "%s(%r)" % (self.__class__, self.__dict__)
+
+# pylint: disable=too-few-public-methods
+class Service:
+    """
+    Simple container to hold a service name.
+    """
+    def __init__(self, network_name, service_name):
+        self.network_name = network_name
+        self.service_name = service_name
+
+    def __repr__(self):
+        return "%s(%r)" % (self.__class__, self.__dict__)

--- a/butter/util/public_blocks.py
+++ b/butter/util/public_blocks.py
@@ -1,0 +1,23 @@
+"""
+Utility to get list of public CIDRs.
+"""
+import ipaddress
+
+def get_public_blocks():
+    """
+    Get public cidrs.
+    """
+    def address_exclude_list(original, exclude):
+        full_network_list = []
+        if not exclude:
+            return [original]
+        if original.overlaps(exclude[0]):
+            for new_block in original.address_exclude(exclude[0]):
+                full_network_list.extend(address_exclude_list(new_block, exclude[1:]))
+        else:
+            full_network_list.extend(address_exclude_list(original, exclude[1:]))
+        return full_network_list
+    return address_exclude_list(
+        ipaddress.IPv4Network("0.0.0.0/0"),
+        [ipaddress.IPv4Network("10.0.0.0/8"), ipaddress.IPv4Network("127.0.0.0/8"),
+         ipaddress.IPv4Network("172.16.0.0/12"), ipaddress.IPv4Network("192.168.0.0/16")])

--- a/example-blueprints/aws-haproxy/blueprint_fixture.py
+++ b/example-blueprints/aws-haproxy/blueprint_fixture.py
@@ -10,6 +10,7 @@ import requests
 from butter.testutils.blueprint_tester import (generate_unique_name,
                                                call_with_retries)
 from butter.testutils.fixture import BlueprintTestInterface, SetupInfo
+from butter.types.networking import Service, CidrBlock
 
 SERVICE_BLUEPRINT = os.path.join(os.path.dirname(__file__),
                                  "../aws-nginx/blueprint.yml")
@@ -40,9 +41,11 @@ class BlueprintTest(BlueprintTestInterface):
         created.
         """
         internal_service_name = setup_info.deployment_info["service_name"]
-        self.client.paths.add(network_name, service_name, internal_service_name,
-                              80)
-        self.client.paths.expose(network_name, service_name, 80)
+        internal_service = Service(network_name, internal_service_name)
+        load_balancer = Service(network_name, service_name)
+        internet = CidrBlock("0.0.0.0/0")
+        self.client.paths.add(load_balancer, internal_service, 80)
+        self.client.paths.add(internet, load_balancer, 80)
 
     def verify(self, network_name, service_name, setup_info):
         """

--- a/tests/blueprint_tester_fixture/blueprint_fixture.py
+++ b/tests/blueprint_tester_fixture/blueprint_fixture.py
@@ -8,6 +8,7 @@ the HAProxy blueprint.
 import os
 from butter.testutils.blueprint_tester import generate_unique_name
 from butter.testutils.fixture import BlueprintTestInterface, SetupInfo
+from butter.types.networking import Service, CidrBlock
 
 SERVICE_BLUEPRINT = os.path.join(os.path.dirname(__file__),
                                  "../../example-blueprints/aws-nginx/blueprint.yml")
@@ -39,9 +40,11 @@ class BlueprintTest(BlueprintTestInterface):
         """
         assert setup_info.deployment_info["service_name"] == SERVICE_NAME
         internal_service_name = setup_info.deployment_info["service_name"]
-        self.client.paths.add(network_name, service_name, internal_service_name,
-                              80)
-        self.client.paths.expose(network_name, service_name, 80)
+        internal_service = Service(network_name, internal_service_name)
+        load_balancer = Service(network_name, service_name)
+        internet = CidrBlock("0.0.0.0/0")
+        self.client.paths.add(load_balancer, internal_service, 80)
+        self.client.paths.add(internet, load_balancer, 80)
 
     def verify(self, network_name, service_name, setup_info):
         """

--- a/tests/test_public_blocks.py
+++ b/tests/test_public_blocks.py
@@ -1,0 +1,22 @@
+"""
+Test library to get public CIDRs.
+"""
+import ipaddress
+import butter.util.public_blocks
+
+def test_public_blocks():
+    """
+    Test that the logic that tells us whether something is internet accessible is correct.
+    """
+    public_address_overlap = False
+    public_blocks = butter.util.public_blocks.get_public_blocks()
+    assert public_blocks
+    for block in public_blocks:
+        assert not ipaddress.IPv4Network("172.16.0.0/12").overlaps(block)
+        assert not ipaddress.IPv4Network("10.0.0.0/8").overlaps(block)
+        assert not ipaddress.IPv4Network("127.0.0.0/8").overlaps(block)
+        assert not ipaddress.IPv4Network("192.168.0.0/16").overlaps(block)
+        assert ipaddress.IPv4Network("0.0.0.0/0").overlaps(block)
+        if ipaddress.IPv4Network("8.8.8.8/32").overlaps(block):
+            public_address_overlap = True
+    assert public_address_overlap


### PR DESCRIPTION
Instead, have a single "add" method that takes either a "Service" object
or a "CidrBlock".  This gives the flexibility to add arbitrary
addresses, and now adds support for removing public access from a
service.

Fixes: https://github.com/sverch/butter/issues/3